### PR TITLE
Updates regarding the Version-2 Aadhaar Cards of 2022

### DIFF
--- a/pyaadhaar/decode.py
+++ b/pyaadhaar/decode.py
@@ -42,9 +42,6 @@ class AadhaarSecureQr:
         
         self.data['adhaar_last_4_digit'] = self.data['referenceid'][0:4]
         self.data['adhaar_last_digit'] = self.data['referenceid'][3]
-
-        # Testing Purpose
-        print(self.data)
         
         if self.data['email_mobile_status'] == "0":
             self.data['email'] = "no"

--- a/pyaadhaar/decode.py
+++ b/pyaadhaar/decode.py
@@ -15,7 +15,7 @@ class AadhaarSecureQr:
 
     def __init__(self, base10encodedstring):
         self.base10encodedstring = base10encodedstring
-        self.details = ["referenceid", "name", "dob", "gender", "careof", "district", "landmark",
+        self.details = ["version","email_mobile_status","referenceid", "name", "dob", "gender", "careof", "district", "landmark",
                         "house", "location", "pincode", "postoffice", "state", "street", "subdistrict", "vtc"]
         self.delimeter = []
         self.data = {}
@@ -25,20 +25,27 @@ class AadhaarSecureQr:
         self.decompressed_array = zlib.decompress(
             bytes_array, 16+zlib.MAX_WBITS)
 
+        # FIX: Patch for the 2022 Aadhaar Cards
+        # The decoded data from these cards is reproducing a 'V2' at 0th and 1st index
+        if not self.decompressed_array[0:2].decode("ISO-8859-1") == 'V2':
+            self.details.pop(0)
+        
+        self.delimeter.append(-1)
         for i in range(len(self.decompressed_array)):
             if self.decompressed_array[i] == 255:
                 self.delimeter.append(i)
 
-        self.data['email_mobile_status'] = self.decompressed_array[0:1].decode(
-            "ISO-8859-1")
+        for i in range(len(self.details)):
+            self.data[self.details[i]] = self.decompressed_array[self.delimeter[i] + 1:self.delimeter[i+1]].decode("ISO-8859-1")
 
-        for i in range(15):
-            self.data[self.details[i]] = self.decompressed_array[self.delimeter[i] +
-                                                                 1:self.delimeter[i+1]].decode("ISO-8859-1")
-
+        
+        
         self.data['adhaar_last_4_digit'] = self.data['referenceid'][0:4]
         self.data['adhaar_last_digit'] = self.data['referenceid'][3]
 
+        # Testing Purpose
+        print(self.data)
+        
         if self.data['email_mobile_status'] == "0":
             self.data['email'] = "no"
             self.data['mobile'] = "no"
@@ -264,3 +271,4 @@ class AadhaarOfflineXML:
             return True
         else:
             return False
+

--- a/pyaadhaar/decode.py
+++ b/pyaadhaar/decode.py
@@ -38,8 +38,6 @@ class AadhaarSecureQr:
         for i in range(len(self.details)):
             self.data[self.details[i]] = self.decompressed_array[self.delimeter[i] + 1:self.delimeter[i+1]].decode("ISO-8859-1")
 
-        
-        
         self.data['adhaar_last_4_digit'] = self.data['referenceid'][0:4]
         self.data['adhaar_last_digit'] = self.data['referenceid'][3]
         


### PR DESCRIPTION
**The Issues which were being faced with the previous version**

1. When uploading a new 2022 Aadhaar Card, the library was through a string index out of bound error.

**Solution for that has been patched in this version**

- Essentially the QR code has an extra parameter of 'V2' at the start of the decompressed data string.  This resulted in a false allocation of data points in the key of "email_mobile_status", creating a problem in the whole parsing procedure. 

**FIX proposed**

- adding"version" and "email_mobile_status" in the details list.
- checking the presence of V2 at the start of the decompressed string. Suppose available V2 gets mapped to "version" from the details list. IF NOT, "version" is popped from the list.
- (-1) is appended at the start of the delimiter list. This helps us map all the details to their corresponding key-value pairs in a single for loop. (This was part of REFACTORING)